### PR TITLE
Fix: RSS link on blog pages now work

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -207,11 +207,11 @@ module.exports = function(grunt) {
         buildDrafts = true;
         break;
       case 'staging':
-        baseUrl = 'http://staging-blog.grafana.com.s3-website-us-west-2.amazonaws.com';
+        baseUrl = 'https://staging.grafana.com/blog';
         buildDrafts = true;
         break;
       case 'prod':
-        baseUrl = 'http://blog.grafana.com.s3-website-us-west-2.amazonaws.com';
+        baseUrl = 'https://grafana.com/blog';
         break;
       case 'staging-docs':
         buildDrafts = true;

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -7,7 +7,7 @@
 		<h1 class="page-letterhead__heading page-letterhead__heading--on-background">{{ .Title }}</h1>
 		<h2 class="page-letterhead__subheading">
 			Published: {{ .Date.Format "2 Jan 2006" }} by {{ $author.name }}
-			<a class="blog-rss-link" href="{{ .RSSLink }}" type="application/rss+xml" target="_blank">
+			<a class="blog-rss-link" href="{{ Site.RSSLink }}" type="application/rss+xml" target="_blank">
 				RSS <i class="fa fa-rss"></i>
 			</a>
 		</h2>


### PR DESCRIPTION

* Fixes RSS link on blog article pages
* Fixes Blog links in the RSS feed xml

This changes the baseUrl to be the production proxy URL which makes the nginx rewrite rules null and void, it seems to work in staging hope it also works in prod. 